### PR TITLE
Simplifying of handle numbers with decimal points.

### DIFF
--- a/src/main/java/att/grappa/ExceptionDisplay.java
+++ b/src/main/java/att/grappa/ExceptionDisplay.java
@@ -12,7 +12,7 @@ package att.grappa;
 /**
  * Implement this interface to register your special exception-displaying solution.
  *
- * @see Grappa#setExceptionDisplay(ExceptionDisplay)xceptionDisplay
+ * @see Grappa#setExceptionDisplay(ExceptionDisplay)
  */
 public interface ExceptionDisplay
 {


### PR DESCRIPTION
I have made a mistake in a previous commit.
The core problem was to handle unquoted numeric values with a decimal point (e.g. `ranksep=1.94444`). In the previous solution I was implemented way to handle unquoted values after '='. But now I realized, that such a function already existed:
```
            // look for an id or keyword
            if (id_char(this.next_char)) {
                return do_id();
            }

```
The only thing to add, is to handle the dot '.' character.

The unquoted handling is not right, as `do_html_string()` and `do_id()` methods are not called any more, as they are recognized as unquoted values.

We might want to also note, that this version is known to be working with graphviz version 2.40.1 (20161225.0304).